### PR TITLE
[#27] 메인 화면 통계, 로드맵 관련 api 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
     implementation 'com.auth0:java-jwt:4.4.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/github/logi/domain/certificate/repository/CertificateRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/certificate/repository/CertificateRepository.java
@@ -125,6 +125,10 @@ public interface CertificateRepository extends JpaRepository<Certificate, UUID> 
     @Query("SELECT COUNT(c) FROM Certificate c WHERE c.user = :user")
     Long countByUser(@Param("user") User user);
 
+    // 여러 유저의 자격증을 한 번에 조회 (N+1 방지)
+    @Query("SELECT c FROM Certificate c WHERE c.user IN :users")
+    List<Certificate> findAllByUserIn(@Param("users") List<User> users);
+
     interface CertNameCountView {
         String getName();
         Long getCnt();

--- a/backend/src/main/java/com/github/logi/domain/certificate/repository/CertificateRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/certificate/repository/CertificateRepository.java
@@ -1,8 +1,12 @@
 package com.github.logi.domain.certificate.repository;
 
 import com.github.logi.domain.certificate.entity.Certificate;
+import com.github.logi.domain.user.entity.KookminDepartment;
+import com.github.logi.domain.user.entity.State;
 import com.github.logi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,4 +15,118 @@ public interface CertificateRepository extends JpaRepository<Certificate, UUID> 
     List<Certificate> findAllByUser(User user);
 
     void deleteAllByUser(User user);
+
+    // major + state 기준 평균 자격증 수
+    @Query("""
+            SELECT COUNT(c) * 1.0 / COUNT(DISTINCT c.user) AS avg
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.state = :state
+            """)
+    Double findLicenseAvgByMajorAndState(
+            @Param("major") KookminDepartment major,
+            @Param("state") State state
+    );
+
+    @Query("""
+            SELECT COUNT(c) * 1.0 / COUNT(DISTINCT c.user) AS avg
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
+            """)
+    Double findLicenseAvgByMajorAndSchoolNum(
+            @Param("major") KookminDepartment major,
+            @Param("schoolNumPrefix") String schoolNumPrefix
+    );
+
+    @Query("""
+            SELECT COUNT(c) * 1.0 / COUNT(DISTINCT c.user) AS avg
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
+            """)
+    Double findLicenseAvgByMajorAndWorker(
+            @Param("major") KookminDepartment major
+    );
+
+    // major + state 기준 자격증 보유 유저 수
+    @Query("""
+            SELECT COUNT(DISTINCT c.user) AS userCount
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.state = :state
+            """)
+    Long findLicenseUserCountByMajorAndState(
+            @Param("major") KookminDepartment major,
+            @Param("state") State state
+    );
+
+    @Query("""
+            SELECT COUNT(DISTINCT c.user) AS userCount
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
+            """)
+    Long findLicenseUserCountByMajorAndSchoolNum(
+            @Param("major") KookminDepartment major,
+            @Param("schoolNumPrefix") String schoolNumPrefix
+    );
+
+    @Query("""
+            SELECT COUNT(DISTINCT c.user) AS userCount
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
+            """)
+    Long findLicenseUserCountByMajorAndWorker(
+            @Param("major") KookminDepartment major
+    );
+
+    // weakPoints 추천용: major + state 기준 자격증명 Top N
+    @Query("""
+            SELECT c.certificateName AS name, COUNT(c) AS cnt
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.state = :state
+            GROUP BY c.certificateName
+            ORDER BY cnt DESC
+            """)
+    List<CertNameCountView> findTopCertNamesByMajorAndState(
+            @Param("major") KookminDepartment major,
+            @Param("state") State state
+    );
+
+    @Query("""
+            SELECT c.certificateName AS name, COUNT(c) AS cnt
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
+            GROUP BY c.certificateName
+            ORDER BY cnt DESC
+            """)
+    List<CertNameCountView> findTopCertNamesByMajorAndSchoolNum(
+            @Param("major") KookminDepartment major,
+            @Param("schoolNumPrefix") String schoolNumPrefix
+    );
+
+    @Query("""
+            SELECT c.certificateName AS name, COUNT(c) AS cnt
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
+            GROUP BY c.certificateName
+            ORDER BY cnt DESC
+            """)
+    List<CertNameCountView> findTopCertNamesByMajorAndWorker(
+            @Param("major") KookminDepartment major
+    );
+
+    // 현재 유저의 자격증 수
+    @Query("SELECT COUNT(c) FROM Certificate c WHERE c.user = :user")
+    Long countByUser(@Param("user") User user);
+
+    interface CertNameCountView {
+        String getName();
+        Long getCnt();
+    }
 }

--- a/backend/src/main/java/com/github/logi/domain/certificate/service/CertificateService.java
+++ b/backend/src/main/java/com/github/logi/domain/certificate/service/CertificateService.java
@@ -6,7 +6,9 @@ import com.github.logi.domain.certificate.entity.Certificate;
 import com.github.logi.domain.certificate.exception.CertificateExceptions;
 import com.github.logi.domain.certificate.repository.CertificateRepository;
 import com.github.logi.domain.user.entity.User;
+import com.github.logi.global.config.CacheConfig;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +22,7 @@ public class CertificateService {
     private final CertificateRepository certificateRepository;
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.USER_STATS_CACHE, allEntries = true)
     public void createCertificate(User user, CertificateRequest request) {
         certificateRepository.save(Certificate.create(user, request));
     }
@@ -29,6 +32,7 @@ public class CertificateService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.USER_STATS_CACHE, allEntries = true)
     public void updateCertificate(User user, UUID certificateId, CertificateRequest request) {
         Certificate certificate = certificateRepository.findById(certificateId)
                 .orElseThrow(CertificateExceptions.CERTIFICATE_NOT_FOUND::toException);
@@ -41,6 +45,7 @@ public class CertificateService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.USER_STATS_CACHE, allEntries = true)
     public void deleteCertificate(User user, UUID certificateId) {
         Certificate certificate = certificateRepository.findById(certificateId)
                 .orElseThrow(CertificateExceptions.CERTIFICATE_NOT_FOUND::toException);

--- a/backend/src/main/java/com/github/logi/domain/experience/repository/ExperienceRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/repository/ExperienceRepository.java
@@ -5,6 +5,7 @@ import com.github.logi.domain.experience.entity.ExperienceCategory;
 import com.github.logi.domain.user.entity.KookminDepartment;
 import com.github.logi.domain.user.entity.State;
 import com.github.logi.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -92,7 +93,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
 
     // major + state 기준 자신을 제외한 최신 경험 제목 Top N (weakPoints 추천)
     @Query("""
-            SELECT e.experienceTitle AS title, e.createdAt AS createdAt
+            SELECT e.experienceTitle AS title
             FROM Experience e
             JOIN e.user u
             WHERE u.major = :major AND u.state = :state AND e.experienceCategory = :category
@@ -103,11 +104,12 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
             @Param("major") KookminDepartment major,
             @Param("state") State state,
             @Param("category") ExperienceCategory category,
-            @Param("me") User me
+            @Param("me") User me,
+            Pageable pageable
     );
 
     @Query("""
-            SELECT e.experienceTitle AS title, e.createdAt AS createdAt
+            SELECT e.experienceTitle AS title
             FROM Experience e
             JOIN e.user u
             WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
@@ -119,11 +121,12 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
             @Param("major") KookminDepartment major,
             @Param("schoolNumPrefix") String schoolNumPrefix,
             @Param("category") ExperienceCategory category,
-            @Param("me") User me
+            @Param("me") User me,
+            Pageable pageable
     );
 
     @Query("""
-            SELECT e.experienceTitle AS title, e.createdAt AS createdAt
+            SELECT e.experienceTitle AS title
             FROM Experience e
             JOIN e.user u
             WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
@@ -134,7 +137,8 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
     List<TitleCountView> findTopTitlesByMajorAndWorkerAndCategory(
             @Param("major") KookminDepartment major,
             @Param("category") ExperienceCategory category,
-            @Param("me") User me
+            @Param("me") User me,
+            Pageable pageable
     );
 
     // 현재 유저의 카테고리별 경험 수
@@ -145,6 +149,13 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
             GROUP BY e.experienceCategory
             """)
     List<CategoryCountView> findUserCategoryCount(@Param("user") User user);
+
+    // 여러 유저의 경험을 한 번에 조회 (N+1 방지)
+    @Query("""
+            SELECT e FROM Experience e
+            WHERE e.user IN :users
+            """)
+    List<Experience> findAllByUserIn(@Param("users") List<User> users);
 
     interface CategoryAvgView {
         ExperienceCategory getCategory();

--- a/backend/src/main/java/com/github/logi/domain/experience/repository/ExperienceRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/repository/ExperienceRepository.java
@@ -1,6 +1,9 @@
 package com.github.logi.domain.experience.repository;
 
 import com.github.logi.domain.experience.entity.Experience;
+import com.github.logi.domain.experience.entity.ExperienceCategory;
+import com.github.logi.domain.user.entity.KookminDepartment;
+import com.github.logi.domain.user.entity.State;
 import com.github.logi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,6 +15,155 @@ import java.util.UUID;
 
 public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
     List<Experience> findAllByUser(User user);
+
+    // major + state 기준 카테고리별 평균 경험 수 (STATE groupBy)
+    @Query("""
+            SELECT e.experienceCategory AS category, COUNT(e) * 1.0 / COUNT(DISTINCT e.user) AS avg
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.state = :state
+            GROUP BY e.experienceCategory
+            """)
+    List<CategoryAvgView> findCategoryAvgByMajorAndState(
+            @Param("major") KookminDepartment major,
+            @Param("state") State state
+    );
+
+    // major + schoolNumber prefix 기준 카테고리별 평균 (SCHOOL_NUM groupBy)
+    @Query("""
+            SELECT e.experienceCategory AS category, COUNT(e) * 1.0 / COUNT(DISTINCT e.user) AS avg
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
+            GROUP BY e.experienceCategory
+            """)
+    List<CategoryAvgView> findCategoryAvgByMajorAndSchoolNum(
+            @Param("major") KookminDepartment major,
+            @Param("schoolNumPrefix") String schoolNumPrefix
+    );
+
+    // major + WORKER 기준 카테고리별 평균 (WORKER groupBy)
+    @Query("""
+            SELECT e.experienceCategory AS category, COUNT(e) * 1.0 / COUNT(DISTINCT e.user) AS avg
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
+            GROUP BY e.experienceCategory
+            """)
+    List<CategoryAvgView> findCategoryAvgByMajorAndWorker(
+            @Param("major") KookminDepartment major
+    );
+
+    // major + state 기준 경험 카테고리별 유저 수 (해당 카테고리를 가진 유저 수)
+    @Query("""
+            SELECT e.experienceCategory AS category, COUNT(DISTINCT e.user) AS userCount
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.state = :state
+            GROUP BY e.experienceCategory
+            """)
+    List<CategoryUserCountView> findCategoryUserCountByMajorAndState(
+            @Param("major") KookminDepartment major,
+            @Param("state") State state
+    );
+
+    @Query("""
+            SELECT e.experienceCategory AS category, COUNT(DISTINCT e.user) AS userCount
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
+            GROUP BY e.experienceCategory
+            """)
+    List<CategoryUserCountView> findCategoryUserCountByMajorAndSchoolNum(
+            @Param("major") KookminDepartment major,
+            @Param("schoolNumPrefix") String schoolNumPrefix
+    );
+
+    @Query("""
+            SELECT e.experienceCategory AS category, COUNT(DISTINCT e.user) AS userCount
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
+            GROUP BY e.experienceCategory
+            """)
+    List<CategoryUserCountView> findCategoryUserCountByMajorAndWorker(
+            @Param("major") KookminDepartment major
+    );
+
+    // major + state 기준 자신을 제외한 최신 경험 제목 Top N (weakPoints 추천)
+    @Query("""
+            SELECT e.experienceTitle AS title, e.createdAt AS createdAt
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.state = :state AND e.experienceCategory = :category
+              AND e.user <> :me
+            ORDER BY e.createdAt DESC
+            """)
+    List<TitleCountView> findTopTitlesByMajorAndStateAndCategory(
+            @Param("major") KookminDepartment major,
+            @Param("state") State state,
+            @Param("category") ExperienceCategory category,
+            @Param("me") User me
+    );
+
+    @Query("""
+            SELECT e.experienceTitle AS title, e.createdAt AS createdAt
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
+              AND e.experienceCategory = :category
+              AND e.user <> :me
+            ORDER BY e.createdAt DESC
+            """)
+    List<TitleCountView> findTopTitlesByMajorAndSchoolNumAndCategory(
+            @Param("major") KookminDepartment major,
+            @Param("schoolNumPrefix") String schoolNumPrefix,
+            @Param("category") ExperienceCategory category,
+            @Param("me") User me
+    );
+
+    @Query("""
+            SELECT e.experienceTitle AS title, e.createdAt AS createdAt
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
+              AND e.experienceCategory = :category
+              AND e.user <> :me
+            ORDER BY e.createdAt DESC
+            """)
+    List<TitleCountView> findTopTitlesByMajorAndWorkerAndCategory(
+            @Param("major") KookminDepartment major,
+            @Param("category") ExperienceCategory category,
+            @Param("me") User me
+    );
+
+    // 현재 유저의 카테고리별 경험 수
+    @Query("""
+            SELECT e.experienceCategory AS category, COUNT(e) AS cnt
+            FROM Experience e
+            WHERE e.user = :user
+            GROUP BY e.experienceCategory
+            """)
+    List<CategoryCountView> findUserCategoryCount(@Param("user") User user);
+
+    interface CategoryAvgView {
+        ExperienceCategory getCategory();
+        Double getAvg();
+    }
+
+    interface CategoryUserCountView {
+        ExperienceCategory getCategory();
+        Long getUserCount();
+    }
+
+    interface TitleCountView {
+        String getTitle();
+    }
+
+    interface CategoryCountView {
+        ExperienceCategory getCategory();
+        Long getCnt();
+    }
 
     @Modifying
     @Query(value = "DELETE FROM experiences WHERE user_id = :userId", nativeQuery = true)

--- a/backend/src/main/java/com/github/logi/domain/experience/service/ExperienceService.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/service/ExperienceService.java
@@ -7,8 +7,10 @@ import com.github.logi.domain.experience.entity.Experience;
 import com.github.logi.domain.experience.exception.ExperienceExceptions;
 import com.github.logi.domain.experience.repository.ExperienceRepository;
 import com.github.logi.domain.user.entity.User;
+import com.github.logi.global.config.CacheConfig;
 import com.github.logi.global.sqs.SqsMessagePublisher;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -25,6 +27,7 @@ public class ExperienceService {
     private final SqsMessagePublisher sqsMessagePublisher;
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.USER_STATS_CACHE, allEntries = true)
     public void createExperience(User user, ExperienceRequest request) {
         Experience experience = experienceRepository.save(Experience.create(user, request));
         UUID experienceId = experience.getId();
@@ -53,6 +56,7 @@ public class ExperienceService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.USER_STATS_CACHE, allEntries = true)
     public void updateExperience(User user, UUID experienceId, ExperienceRequest request) {
         Experience experience = experienceRepository.findById(experienceId)
                 .orElseThrow(ExperienceExceptions.EXPERIENCE_NOT_FOUND::toException);
@@ -72,6 +76,7 @@ public class ExperienceService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.USER_STATS_CACHE, allEntries = true)
     public void deleteExperience(User user, UUID experienceId) {
         Experience experience = experienceRepository.findById(experienceId)
                 .orElseThrow(ExperienceExceptions.EXPERIENCE_NOT_FOUND::toException);

--- a/backend/src/main/java/com/github/logi/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/github/logi/domain/user/controller/UserController.java
@@ -1,10 +1,12 @@
 package com.github.logi.domain.user.controller;
 
 import com.github.logi.domain.user.dto.request.UserMeRequest;
+import com.github.logi.domain.user.dto.response.DashboardResponse;
 import com.github.logi.domain.user.dto.response.UserMeResponse;
 import com.github.logi.domain.user.dto.response.UserStatsResponse;
 import com.github.logi.domain.user.entity.GroupBy;
 import com.github.logi.domain.user.entity.User;
+import com.github.logi.domain.user.service.DashboardService;
 import com.github.logi.domain.user.service.UserService;
 import com.github.logi.domain.user.service.UserStatsService;
 import com.github.logi.global.dto.ApiResponse;
@@ -27,6 +29,7 @@ public class UserController {
 
     private final UserService userService;
     private final UserStatsService userStatsService;
+    private final DashboardService dashboardService;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 정보를 반환합니다.")
     @GetMapping("/me")
@@ -59,5 +62,19 @@ public class UserController {
             @RequestParam GroupBy groupBy
     ) {
         return ApiResponse.ok(userStatsService.getStats(user, groupBy));
+    }
+
+    @Operation(
+            summary = "메인 대시보드 조회",
+            description = """
+                    현재 로그인한 유저의 메인 화면 데이터를 반환합니다.
+                    - statistics: 동일 학과 + 동일 학년(STATE) 기준 경험·자격증 평균 및 내 현황
+                    - userExperiences: 내 경험·자격증 목록
+                    - graduateUserExperiences: 동일 학과 + 희망 직무(jobFirst) 겹치는 합격자(WORKER) 최신 2명의 경험·자격증
+                    """
+    )
+    @GetMapping("/me/dashboard")
+    public ApiResponse<DashboardResponse> getDashboard(@AuthenticationPrincipal User user) {
+        return ApiResponse.ok(dashboardService.getDashboard(user));
     }
 }

--- a/backend/src/main/java/com/github/logi/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/github/logi/domain/user/controller/UserController.java
@@ -2,8 +2,11 @@ package com.github.logi.domain.user.controller;
 
 import com.github.logi.domain.user.dto.request.UserMeRequest;
 import com.github.logi.domain.user.dto.response.UserMeResponse;
+import com.github.logi.domain.user.dto.response.UserStatsResponse;
+import com.github.logi.domain.user.entity.GroupBy;
 import com.github.logi.domain.user.entity.User;
 import com.github.logi.domain.user.service.UserService;
+import com.github.logi.domain.user.service.UserStatsService;
 import com.github.logi.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "유저 API")
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final UserStatsService userStatsService;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 정보를 반환합니다.")
     @GetMapping("/me")
@@ -36,5 +41,23 @@ public class UserController {
             @RequestBody UserMeRequest request
     ) {
         return ApiResponse.ok(userService.updateMe(user, request));
+    }
+
+    @Operation(
+            summary = "내 통계 조회",
+            description = """
+                    현재 로그인한 유저의 경험·자격증 통계와 부족한 점(약점)을 반환합니다.
+                    groupBy 파라미터로 비교 대상을 지정합니다.
+                    - STATE: 동일 학과 + 동일 학년(State) 기준
+                    - SCHOOL_NUM: 동일 학과 + 동일 입학연도(학번 앞 2자리) 기준
+                    - WORKER: 동일 학과 합격자(WORKER) 기준
+                    """
+    )
+    @GetMapping("/me/stats")
+    public ApiResponse<UserStatsResponse> getStats(
+            @AuthenticationPrincipal User user,
+            @RequestParam GroupBy groupBy
+    ) {
+        return ApiResponse.ok(userStatsService.getStats(user, groupBy));
     }
 }

--- a/backend/src/main/java/com/github/logi/domain/user/dto/response/DashboardResponse.java
+++ b/backend/src/main/java/com/github/logi/domain/user/dto/response/DashboardResponse.java
@@ -1,0 +1,60 @@
+package com.github.logi.domain.user.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public record DashboardResponse(
+        Statistics statistics,
+        UserExperiences userExperiences,
+        List<GraduateUserExperiences> graduateUserExperiences
+) {
+
+    public record Statistics(
+            float partTimeAvg,
+            float internAvg,
+            float licenseAvg,
+            float internalAvg,
+            float externalAvg,
+            UserCounts user
+    ) {
+        public static float round1(double value) {
+            return (float) (Math.round(value * 10) / 10.0);
+        }
+
+        public record UserCounts(
+                int partTimeCount,
+                int internCount,
+                int licenseCount,
+                int internalCount,
+                int externalCount
+        ) {
+        }
+    }
+
+    public record UserExperiences(
+            List<ExperienceItem> partTimeHistory,
+            List<ExperienceItem> internHistory,
+            List<ExperienceItem> licenseHistory,
+            List<ExperienceItem> internalHistory,
+            List<ExperienceItem> externalHistory
+    ) {
+    }
+
+    public record ExperienceItem(
+            String name,
+            UUID experienceId,
+            String startDate,
+            String endDate
+    ) {
+    }
+
+    public record GraduateUserExperiences(
+            UUID userId,
+            List<ExperienceItem> partTimeHistory,
+            List<ExperienceItem> internHistory,
+            List<ExperienceItem> licenseHistory,
+            List<ExperienceItem> internalHistory,
+            List<ExperienceItem> externalHistory
+    ) {
+    }
+}

--- a/backend/src/main/java/com/github/logi/domain/user/dto/response/UserStatsResponse.java
+++ b/backend/src/main/java/com/github/logi/domain/user/dto/response/UserStatsResponse.java
@@ -1,0 +1,47 @@
+package com.github.logi.domain.user.dto.response;
+
+import com.github.logi.domain.experience.entity.ExperienceCategory;
+
+import java.util.List;
+
+public record UserStatsResponse(
+        Statistics statistics,
+        List<WeakPoint> weakPoints
+) {
+
+    public record Statistics(
+            CategoryStat partTime,
+            CategoryStat external,
+            CategoryStat internal,
+            CategoryStat license,
+            CategoryStat intern
+    ) {
+    }
+
+    public record CategoryStat(
+            float avg,
+            int userCount,
+            int myCount
+    ) {
+        public static CategoryStat of(double avg, long userCount, long myCount) {
+            return new CategoryStat((float) avg, (int) userCount, (int) myCount);
+        }
+
+        public static CategoryStat empty(long myCount) {
+            return new CategoryStat(0f, 0, (int) myCount);
+        }
+    }
+
+    public record WeakPoint(
+            String type,
+            List<String> recommendedItems
+    ) {
+        public static WeakPoint of(ExperienceCategory category, List<String> items) {
+            return new WeakPoint(category.name(), items);
+        }
+
+        public static WeakPoint license(List<String> items) {
+            return new WeakPoint("LICENSE", items);
+        }
+    }
+}

--- a/backend/src/main/java/com/github/logi/domain/user/dto/response/UserStatsResponse.java
+++ b/backend/src/main/java/com/github/logi/domain/user/dto/response/UserStatsResponse.java
@@ -24,11 +24,15 @@ public record UserStatsResponse(
             int myCount
     ) {
         public static CategoryStat of(double avg, long userCount, long myCount) {
-            return new CategoryStat((float) avg, (int) userCount, (int) myCount);
+            return new CategoryStat(round1(avg), (int) userCount, (int) myCount);
         }
 
         public static CategoryStat empty(long myCount) {
             return new CategoryStat(0f, 0, (int) myCount);
+        }
+
+        private static float round1(double value) {
+            return (float) (Math.round(value * 10) / 10.0);
         }
     }
 

--- a/backend/src/main/java/com/github/logi/domain/user/entity/GroupBy.java
+++ b/backend/src/main/java/com/github/logi/domain/user/entity/GroupBy.java
@@ -1,0 +1,7 @@
+package com.github.logi.domain.user.entity;
+
+public enum GroupBy {
+    STATE,
+    SCHOOL_NUM,
+    WORKER
+}

--- a/backend/src/main/java/com/github/logi/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/user/repository/UserRepository.java
@@ -1,12 +1,61 @@
 package com.github.logi.domain.user.repository;
 
+import com.github.logi.domain.user.entity.JobFirst;
+import com.github.logi.domain.user.entity.JobSecond;
+import com.github.logi.domain.user.entity.JobThird;
+import com.github.logi.domain.user.entity.KookminDepartment;
 import com.github.logi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByEmail(String email);
+
+    @Query("""
+            SELECT u FROM User u
+            WHERE u.major = :major
+              AND u.state = com.github.logi.domain.user.entity.State.WORKER
+              AND u.jobThird = :jobThird
+              AND u <> :me
+            ORDER BY u.createdAt DESC
+            """)
+    List<User> findWorkersByMajorAndJobThird(
+            @Param("major") KookminDepartment major,
+            @Param("jobThird") JobThird jobThird,
+            @Param("me") User me
+    );
+
+    @Query("""
+            SELECT u FROM User u
+            WHERE u.major = :major
+              AND u.state = com.github.logi.domain.user.entity.State.WORKER
+              AND u.jobSecond = :jobSecond
+              AND u <> :me
+            ORDER BY u.createdAt DESC
+            """)
+    List<User> findWorkersByMajorAndJobSecond(
+            @Param("major") KookminDepartment major,
+            @Param("jobSecond") JobSecond jobSecond,
+            @Param("me") User me
+    );
+
+    @Query("""
+            SELECT u FROM User u
+            WHERE u.major = :major
+              AND u.state = com.github.logi.domain.user.entity.State.WORKER
+              AND u.jobFirst = :jobFirst
+              AND u <> :me
+            ORDER BY u.createdAt DESC
+            """)
+    List<User> findWorkersByMajorAndJobFirst(
+            @Param("major") KookminDepartment major,
+            @Param("jobFirst") JobFirst jobFirst,
+            @Param("me") User me
+    );
 }

--- a/backend/src/main/java/com/github/logi/domain/user/service/DashboardService.java
+++ b/backend/src/main/java/com/github/logi/domain/user/service/DashboardService.java
@@ -1,0 +1,159 @@
+package com.github.logi.domain.user.service;
+
+import com.github.logi.domain.certificate.entity.Certificate;
+import com.github.logi.domain.certificate.repository.CertificateRepository;
+import com.github.logi.domain.experience.entity.Experience;
+import com.github.logi.domain.experience.entity.ExperienceCategory;
+import com.github.logi.domain.experience.repository.ExperienceRepository;
+import com.github.logi.domain.user.dto.response.DashboardResponse;
+import com.github.logi.domain.user.dto.response.DashboardResponse.ExperienceItem;
+import com.github.logi.domain.user.dto.response.DashboardResponse.GraduateUserExperiences;
+import com.github.logi.domain.user.dto.response.DashboardResponse.Statistics;
+import com.github.logi.domain.user.dto.response.DashboardResponse.Statistics.UserCounts;
+import com.github.logi.domain.user.dto.response.DashboardResponse.UserExperiences;
+import com.github.logi.domain.user.entity.User;
+import com.github.logi.domain.user.repository.UserRepository;
+import com.github.logi.domain.user.service.GroupStatsService.GroupAvgResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.github.logi.domain.user.entity.GroupBy.STATE;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardService {
+
+    private final ExperienceRepository experienceRepository;
+    private final CertificateRepository certificateRepository;
+    private final UserRepository userRepository;
+    private final GroupStatsService groupStatsService;
+
+    public DashboardResponse getDashboard(User user) {
+        String groupKey = user.getState() != null ? user.getState().name() : "";
+        GroupAvgResult groupAvg = groupStatsService.fetchGroupAvg(user.getMajor(), STATE, groupKey, user.getState());
+
+        // 내 경험/자격증 한 번만 조회 → statistics + userExperiences 양쪽에서 재사용
+        List<Experience> myExperiences = experienceRepository.findAllByUser(user);
+        List<Certificate> myCertificates = certificateRepository.findAllByUser(user);
+        Map<ExperienceCategory, List<Experience>> myByCategory = myExperiences.stream()
+                .collect(Collectors.groupingBy(Experience::getExperienceCategory));
+
+        Statistics statistics = buildStatistics(myByCategory, myCertificates, groupAvg);
+        UserExperiences userExperiences = buildUserExperiences(myByCategory, myCertificates);
+        List<GraduateUserExperiences> graduateUserExperiences = buildGraduateUserExperiences(user);
+
+        return new DashboardResponse(statistics, userExperiences, graduateUserExperiences);
+    }
+
+    private Statistics buildStatistics(
+            Map<ExperienceCategory, List<Experience>> myByCategory,
+            List<Certificate> myCertificates,
+            GroupAvgResult groupAvg
+    ) {
+        return new Statistics(
+                Statistics.round1(groupAvg.avgMap().getOrDefault(ExperienceCategory.PARTTIME, 0.0)),
+                Statistics.round1(groupAvg.avgMap().getOrDefault(ExperienceCategory.INTERN, 0.0)),
+                Statistics.round1(groupAvg.licenseAvg()),
+                Statistics.round1(groupAvg.avgMap().getOrDefault(ExperienceCategory.INTERNAL, 0.0)),
+                Statistics.round1(groupAvg.avgMap().getOrDefault(ExperienceCategory.EXTERNAL, 0.0)),
+                new UserCounts(
+                        myByCategory.getOrDefault(ExperienceCategory.PARTTIME, List.of()).size(),
+                        myByCategory.getOrDefault(ExperienceCategory.INTERN, List.of()).size(),
+                        myCertificates.size(),
+                        myByCategory.getOrDefault(ExperienceCategory.INTERNAL, List.of()).size(),
+                        myByCategory.getOrDefault(ExperienceCategory.EXTERNAL, List.of()).size()
+                )
+        );
+    }
+
+    private UserExperiences buildUserExperiences(
+            Map<ExperienceCategory, List<Experience>> myByCategory,
+            List<Certificate> myCertificates
+    ) {
+        return new UserExperiences(
+                toExperienceItems(myByCategory.getOrDefault(ExperienceCategory.PARTTIME, List.of())),
+                toExperienceItems(myByCategory.getOrDefault(ExperienceCategory.INTERN, List.of())),
+                toCertificateItems(myCertificates),
+                toExperienceItems(myByCategory.getOrDefault(ExperienceCategory.INTERNAL, List.of())),
+                toExperienceItems(myByCategory.getOrDefault(ExperienceCategory.EXTERNAL, List.of()))
+        );
+    }
+
+    private List<GraduateUserExperiences> buildGraduateUserExperiences(User user) {
+        List<User> workers = findMatchingWorkers(user);
+        if (workers.isEmpty()) {
+            return List.of();
+        }
+
+        // IN 쿼리로 한 번에 조회 (N+1 방지)
+        List<Experience> allWorkerExperiences = experienceRepository.findAllByUserIn(workers);
+        List<Certificate> allWorkerCertificates = certificateRepository.findAllByUserIn(workers);
+
+        Map<UUID, List<Experience>> expByWorker = allWorkerExperiences.stream()
+                .collect(Collectors.groupingBy(e -> e.getUser().getId()));
+        Map<UUID, List<Certificate>> certByWorker = allWorkerCertificates.stream()
+                .collect(Collectors.groupingBy(c -> c.getUser().getId()));
+
+        return workers.stream()
+                .map(worker -> {
+                    Map<ExperienceCategory, List<Experience>> byCategory = expByWorker
+                            .getOrDefault(worker.getId(), List.of()).stream()
+                            .collect(Collectors.groupingBy(Experience::getExperienceCategory));
+                    List<Certificate> certs = certByWorker.getOrDefault(worker.getId(), List.of());
+
+                    return new GraduateUserExperiences(
+                            worker.getId(),
+                            toExperienceItems(byCategory.getOrDefault(ExperienceCategory.PARTTIME, List.of())),
+                            toExperienceItems(byCategory.getOrDefault(ExperienceCategory.INTERN, List.of())),
+                            toCertificateItems(certs),
+                            toExperienceItems(byCategory.getOrDefault(ExperienceCategory.INTERNAL, List.of())),
+                            toExperienceItems(byCategory.getOrDefault(ExperienceCategory.EXTERNAL, List.of()))
+                    );
+                })
+                .toList();
+    }
+
+    private List<User> findMatchingWorkers(User user) {
+        if (user.getJobThird() != null) {
+            List<User> result = userRepository.findWorkersByMajorAndJobThird(user.getMajor(), user.getJobThird(), user);
+            if (!result.isEmpty()) return result;
+        }
+        if (user.getJobSecond() != null) {
+            List<User> result = userRepository.findWorkersByMajorAndJobSecond(user.getMajor(), user.getJobSecond(), user);
+            if (!result.isEmpty()) return result;
+        }
+        if (user.getJobFirst() != null) {
+            return userRepository.findWorkersByMajorAndJobFirst(user.getMajor(), user.getJobFirst(), user);
+        }
+        return List.of();
+    }
+
+    private List<ExperienceItem> toExperienceItems(List<Experience> experiences) {
+        return experiences.stream()
+                .map(e -> new ExperienceItem(
+                        e.getExperienceTitle(),
+                        e.getId(),
+                        e.getStartDate() != null ? e.getStartDate().toString() : null,
+                        e.getEndDate() != null ? e.getEndDate().toString() : null
+                ))
+                .toList();
+    }
+
+    private List<ExperienceItem> toCertificateItems(List<Certificate> certificates) {
+        return certificates.stream()
+                .map(c -> new ExperienceItem(
+                        c.getCertificateName(),
+                        c.getId(),
+                        null,
+                        c.getExpirationDate()
+                ))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/github/logi/domain/user/service/GroupStatsService.java
+++ b/backend/src/main/java/com/github/logi/domain/user/service/GroupStatsService.java
@@ -1,0 +1,90 @@
+package com.github.logi.domain.user.service;
+
+import com.github.logi.domain.certificate.repository.CertificateRepository;
+import com.github.logi.domain.experience.entity.ExperienceCategory;
+import com.github.logi.domain.experience.repository.ExperienceRepository;
+import com.github.logi.domain.user.entity.GroupBy;
+import com.github.logi.domain.user.entity.KookminDepartment;
+import com.github.logi.domain.user.entity.State;
+import com.github.logi.global.config.CacheConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 그룹 집계 결과를 캐싱하는 서비스.
+ * UserStatsService 내부에서 자기 자신을 호출하면 Spring AOP 프록시를 우회하므로
+ * 별도 Bean으로 분리하여 @Cacheable이 정상 동작하도록 한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupStatsService {
+
+    private final ExperienceRepository experienceRepository;
+    private final CertificateRepository certificateRepository;
+
+    @Cacheable(
+            cacheNames = CacheConfig.USER_STATS_CACHE,
+            key = "#major.name() + '_' + #groupBy.name() + '_' + #groupKey"
+    )
+    public GroupAvgResult fetchGroupAvg(KookminDepartment major, GroupBy groupBy, String groupKey, State state) {
+        List<ExperienceRepository.CategoryAvgView> expAvgList;
+        List<ExperienceRepository.CategoryUserCountView> expUserCountList;
+        Double licenseAvg;
+        Long licenseUserCount;
+
+        switch (groupBy) {
+            case STATE -> {
+                expAvgList = experienceRepository.findCategoryAvgByMajorAndState(major, state);
+                expUserCountList = experienceRepository.findCategoryUserCountByMajorAndState(major, state);
+                licenseAvg = certificateRepository.findLicenseAvgByMajorAndState(major, state);
+                licenseUserCount = certificateRepository.findLicenseUserCountByMajorAndState(major, state);
+            }
+            case SCHOOL_NUM -> {
+                expAvgList = experienceRepository.findCategoryAvgByMajorAndSchoolNum(major, groupKey);
+                expUserCountList = experienceRepository.findCategoryUserCountByMajorAndSchoolNum(major, groupKey);
+                licenseAvg = certificateRepository.findLicenseAvgByMajorAndSchoolNum(major, groupKey);
+                licenseUserCount = certificateRepository.findLicenseUserCountByMajorAndSchoolNum(major, groupKey);
+            }
+            case WORKER -> {
+                expAvgList = experienceRepository.findCategoryAvgByMajorAndWorker(major);
+                expUserCountList = experienceRepository.findCategoryUserCountByMajorAndWorker(major);
+                licenseAvg = certificateRepository.findLicenseAvgByMajorAndWorker(major);
+                licenseUserCount = certificateRepository.findLicenseUserCountByMajorAndWorker(major);
+            }
+            default -> throw new IllegalArgumentException("Unsupported groupBy: " + groupBy);
+        }
+
+        Map<ExperienceCategory, Double> avgMap = expAvgList.stream()
+                .collect(Collectors.toMap(
+                        ExperienceRepository.CategoryAvgView::getCategory,
+                        v -> v.getAvg() != null ? v.getAvg() : 0.0
+                ));
+        Map<ExperienceCategory, Long> userCountMap = expUserCountList.stream()
+                .collect(Collectors.toMap(
+                        ExperienceRepository.CategoryUserCountView::getCategory,
+                        v -> v.getUserCount() != null ? v.getUserCount() : 0L
+                ));
+
+        return new GroupAvgResult(
+                avgMap,
+                userCountMap,
+                licenseAvg != null ? licenseAvg : 0.0,
+                licenseUserCount != null ? licenseUserCount : 0L
+        );
+    }
+
+    public record GroupAvgResult(
+            Map<ExperienceCategory, Double> avgMap,
+            Map<ExperienceCategory, Long> userCountMap,
+            double licenseAvg,
+            long licenseUserCount
+    ) {
+    }
+}

--- a/backend/src/main/java/com/github/logi/domain/user/service/UserStatsService.java
+++ b/backend/src/main/java/com/github/logi/domain/user/service/UserStatsService.java
@@ -1,0 +1,140 @@
+package com.github.logi.domain.user.service;
+
+import com.github.logi.domain.certificate.repository.CertificateRepository;
+import com.github.logi.domain.experience.entity.ExperienceCategory;
+import com.github.logi.domain.experience.repository.ExperienceRepository;
+import com.github.logi.domain.user.dto.response.UserStatsResponse;
+import com.github.logi.domain.user.dto.response.UserStatsResponse.CategoryStat;
+import com.github.logi.domain.user.dto.response.UserStatsResponse.Statistics;
+import com.github.logi.domain.user.dto.response.UserStatsResponse.WeakPoint;
+import com.github.logi.domain.user.entity.GroupBy;
+import com.github.logi.domain.user.entity.KookminDepartment;
+import com.github.logi.domain.user.entity.State;
+import com.github.logi.domain.user.entity.User;
+import com.github.logi.domain.user.service.GroupStatsService.GroupAvgResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserStatsService {
+
+    private static final int RECOMMEND_TOP_N = 3;
+
+    private final ExperienceRepository experienceRepository;
+    private final CertificateRepository certificateRepository;
+    private final GroupStatsService groupStatsService;
+
+    public UserStatsResponse getStats(User user, GroupBy groupBy) {
+        GroupContext ctx = buildContext(user, groupBy);
+        GroupAvgResult groupAvg = groupStatsService.fetchGroupAvg(user.getMajor(), ctx.groupBy(), ctx.groupKey(), ctx.state());
+
+        Map<ExperienceCategory, Long> myCountMap = experienceRepository.findUserCategoryCount(user).stream()
+                .collect(Collectors.toMap(
+                        ExperienceRepository.CategoryCountView::getCategory,
+                        ExperienceRepository.CategoryCountView::getCnt
+                ));
+        long myLicenseCount = certificateRepository.countByUser(user);
+
+        Statistics statistics = buildStatistics(groupAvg, myCountMap, myLicenseCount);
+        List<WeakPoint> weakPoints = buildWeakPoints(user, ctx, statistics);
+        return new UserStatsResponse(statistics, weakPoints);
+    }
+
+    private Statistics buildStatistics(GroupAvgResult groupAvg, Map<ExperienceCategory, Long> myCountMap, long myLicenseCount) {
+        return new Statistics(
+                buildCategoryStat(ExperienceCategory.PARTTIME, groupAvg, myCountMap),
+                buildCategoryStat(ExperienceCategory.EXTERNAL, groupAvg, myCountMap),
+                buildCategoryStat(ExperienceCategory.INTERNAL, groupAvg, myCountMap),
+                CategoryStat.of(groupAvg.licenseAvg(), groupAvg.licenseUserCount(), myLicenseCount),
+                buildCategoryStat(ExperienceCategory.INTERN, groupAvg, myCountMap)
+        );
+    }
+
+    private CategoryStat buildCategoryStat(
+            ExperienceCategory category,
+            GroupAvgResult groupAvg,
+            Map<ExperienceCategory, Long> myCountMap
+    ) {
+        double avg = groupAvg.avgMap().getOrDefault(category, 0.0);
+        long userCount = groupAvg.userCountMap().getOrDefault(category, 0L);
+        long myCount = myCountMap.getOrDefault(category, 0L);
+        return CategoryStat.of(avg, userCount, myCount);
+    }
+
+    private List<WeakPoint> buildWeakPoints(User user, GroupContext ctx, Statistics statistics) {
+        List<WeakPoint> weakPoints = new ArrayList<>();
+
+        checkExperienceWeakPoint(user, ctx, ExperienceCategory.PARTTIME, statistics.partTime(), weakPoints);
+        checkExperienceWeakPoint(user, ctx, ExperienceCategory.EXTERNAL, statistics.external(), weakPoints);
+        checkExperienceWeakPoint(user, ctx, ExperienceCategory.INTERNAL, statistics.internal(), weakPoints);
+        checkExperienceWeakPoint(user, ctx, ExperienceCategory.INTERN, statistics.intern(), weakPoints);
+
+        if (statistics.license().myCount() < statistics.license().avg()) {
+            List<String> recommendedCerts = fetchTopCertNames(user.getMajor(), ctx);
+            weakPoints.add(WeakPoint.license(recommendedCerts));
+        }
+
+        return weakPoints;
+    }
+
+    private void checkExperienceWeakPoint(
+            User user,
+            GroupContext ctx,
+            ExperienceCategory category,
+            CategoryStat stat,
+            List<WeakPoint> weakPoints
+    ) {
+        if (stat.myCount() < stat.avg()) {
+            List<String> topTitles = fetchTopExperienceTitles(user, ctx, category);
+            weakPoints.add(WeakPoint.of(category, topTitles));
+        }
+    }
+
+    private List<String> fetchTopExperienceTitles(User user, GroupContext ctx, ExperienceCategory category) {
+        List<ExperienceRepository.TitleCountView> views = switch (ctx.groupBy()) {
+            case STATE -> experienceRepository.findTopTitlesByMajorAndStateAndCategory(user.getMajor(), ctx.state(), category, user);
+            case SCHOOL_NUM -> experienceRepository.findTopTitlesByMajorAndSchoolNumAndCategory(user.getMajor(), ctx.groupKey(), category, user);
+            case WORKER -> experienceRepository.findTopTitlesByMajorAndWorkerAndCategory(user.getMajor(), category, user);
+        };
+        return views.stream()
+                .limit(RECOMMEND_TOP_N)
+                .map(ExperienceRepository.TitleCountView::getTitle)
+                .toList();
+    }
+
+    private List<String> fetchTopCertNames(KookminDepartment major, GroupContext ctx) {
+        List<CertificateRepository.CertNameCountView> views = switch (ctx.groupBy()) {
+            case STATE -> certificateRepository.findTopCertNamesByMajorAndState(major, ctx.state());
+            case SCHOOL_NUM -> certificateRepository.findTopCertNamesByMajorAndSchoolNum(major, ctx.groupKey());
+            case WORKER -> certificateRepository.findTopCertNamesByMajorAndWorker(major);
+        };
+        return views.stream()
+                .limit(RECOMMEND_TOP_N)
+                .map(CertificateRepository.CertNameCountView::getName)
+                .toList();
+    }
+
+    private GroupContext buildContext(User user, GroupBy groupBy) {
+        return switch (groupBy) {
+            case STATE -> new GroupContext(groupBy, user.getState() != null ? user.getState().name() : "", user.getState());
+            case SCHOOL_NUM -> {
+                String prefix = user.getSchoolNumber() != null && user.getSchoolNumber().length() >= 2
+                        ? user.getSchoolNumber().substring(0, 2)
+                        : "";
+                yield new GroupContext(groupBy, prefix, null);
+            }
+            case WORKER -> new GroupContext(groupBy, "WORKER", State.WORKER);
+        };
+    }
+
+    public record GroupContext(GroupBy groupBy, String groupKey, State state) {
+    }
+}

--- a/backend/src/main/java/com/github/logi/domain/user/service/UserStatsService.java
+++ b/backend/src/main/java/com/github/logi/domain/user/service/UserStatsService.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.PageRequest;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -99,13 +101,13 @@ public class UserStatsService {
     }
 
     private List<String> fetchTopExperienceTitles(User user, GroupContext ctx, ExperienceCategory category) {
+        PageRequest page = PageRequest.of(0, RECOMMEND_TOP_N);
         List<ExperienceRepository.TitleCountView> views = switch (ctx.groupBy()) {
-            case STATE -> experienceRepository.findTopTitlesByMajorAndStateAndCategory(user.getMajor(), ctx.state(), category, user);
-            case SCHOOL_NUM -> experienceRepository.findTopTitlesByMajorAndSchoolNumAndCategory(user.getMajor(), ctx.groupKey(), category, user);
-            case WORKER -> experienceRepository.findTopTitlesByMajorAndWorkerAndCategory(user.getMajor(), category, user);
+            case STATE -> experienceRepository.findTopTitlesByMajorAndStateAndCategory(user.getMajor(), ctx.state(), category, user, page);
+            case SCHOOL_NUM -> experienceRepository.findTopTitlesByMajorAndSchoolNumAndCategory(user.getMajor(), ctx.groupKey(), category, user, page);
+            case WORKER -> experienceRepository.findTopTitlesByMajorAndWorkerAndCategory(user.getMajor(), category, user, page);
         };
         return views.stream()
-                .limit(RECOMMEND_TOP_N)
                 .map(ExperienceRepository.TitleCountView::getTitle)
                 .toList();
     }

--- a/backend/src/main/java/com/github/logi/global/config/CacheConfig.java
+++ b/backend/src/main/java/com/github/logi/global/config/CacheConfig.java
@@ -1,0 +1,23 @@
+package com.github.logi.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    public static final String USER_STATS_CACHE = "userStats";
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager(USER_STATS_CACHE);
+        manager.setCaffeineSpec(
+                com.github.benmanes.caffeine.cache.CaffeineSpec.parse("maximumSize=500,expireAfterWrite=10m")
+        );
+        return manager;
+    }
+}


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->
## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

- GET /users/me/stats?groupBy={STATE|SCHOOL_NUM|WORKER} — 동일 학과 기준 경험·자격증 통계 및 약점 조회 API 추가                                                                                                                                            
- GET /users/me/dashboard — 메인 화면용 대시보드 API 추가 (STATE 기준 통계 + 내 경험 목록 + 희망 직무 겹치는 합격자 로드맵)

통계 API (/users/me/stats)
  - GroupBy enum으로 비교 대상 선택 (STATE: 학년, SCHOOL_NUM: 입학연도, WORKER: 합격자)
  - 그룹 평균 대비 부족한 항목을 weakPoints로 반환, 해당 그룹 최신 경험 제목 Top 3 추천
  - GroupStatsService를 별도 Bean으로 분리해 @Cacheable 정상 동작 보장

  대시보드 API (/users/me/dashboard)
  - 통계는 STATE 기준 고정
  - 졸업자(WORKER) 매칭은 jobThird → jobSecond → jobFirst 순으로 폴백
  - 매칭된 WORKER 최신 가입순 2명의 경험·자격증 로드맵 반환



- [x] 새로운 기능 추가
- [x] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [x] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다
- [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)

## 📝 추가 노트


