### PR TITLE
[#29] 경험 저장 시 경험이 언제 생성되었는지에 대한 필드 추가 및 관련 로직 변경

### DIFF
--- a/backend/src/main/java/com/github/logi/domain/experience/dto/request/ExperienceRequest.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/dto/request/ExperienceRequest.java
@@ -1,6 +1,7 @@
 package com.github.logi.domain.experience.dto.request;
 
 import com.github.logi.domain.experience.entity.ExperienceCategory;
+import com.github.logi.domain.user.entity.State;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,6 +11,7 @@ import java.time.LocalDate;
 
 public record ExperienceRequest(
         @NotNull ExperienceCategory experienceCategory,
+        @NotNull State stateAtCreation,
         @NotBlank @Size(max = 100) String relatedMajor,
         @NotBlank @Size(max = 200) String experienceTitle,
         @NotNull @PastOrPresent LocalDate startDate,

--- a/backend/src/main/java/com/github/logi/domain/experience/dto/response/ExperienceResponse.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/dto/response/ExperienceResponse.java
@@ -2,6 +2,7 @@ package com.github.logi.domain.experience.dto.response;
 
 import com.github.logi.domain.experience.entity.Experience;
 import com.github.logi.domain.experience.entity.ExperienceCategory;
+import com.github.logi.domain.user.entity.State;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -9,6 +10,7 @@ import java.util.UUID;
 public record ExperienceResponse(
         UUID experienceId,
         ExperienceCategory experienceCategory,
+        State stateAtCreation,
         String relatedMajor,
         String experienceTitle,
         LocalDate startDate,
@@ -27,6 +29,7 @@ public record ExperienceResponse(
         return new ExperienceResponse(
                 experience.getId(),
                 experience.getExperienceCategory(),
+                experience.getStateAtCreation(),
                 experience.getRelatedMajor(),
                 experience.getExperienceTitle(),
                 experience.getStartDate(),

--- a/backend/src/main/java/com/github/logi/domain/experience/entity/Experience.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/entity/Experience.java
@@ -69,7 +69,7 @@ public class Experience extends BaseEntity {
     public static Experience create(User user, ExperienceRequest request) {
         Experience experience = new Experience();
         experience.user = user;
-        experience.stateAtCreation = user.getState();
+        experience.stateAtCreation = request.stateAtCreation();
         experience.experienceCategory = request.experienceCategory();
         experience.relatedMajor = request.relatedMajor();
         experience.experienceTitle = request.experienceTitle();
@@ -88,6 +88,7 @@ public class Experience extends BaseEntity {
 
     public void update(ExperienceRequest request) {
         this.experienceCategory = request.experienceCategory();
+        this.stateAtCreation = request.stateAtCreation();
         this.relatedMajor = request.relatedMajor();
         this.experienceTitle = request.experienceTitle();
         this.startDate = request.startDate();

--- a/backend/src/main/java/com/github/logi/domain/experience/entity/Experience.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/entity/Experience.java
@@ -1,6 +1,7 @@
 package com.github.logi.domain.experience.entity;
 
 import com.github.logi.domain.experience.dto.request.ExperienceRequest;
+import com.github.logi.domain.user.entity.State;
 import com.github.logi.domain.user.entity.User;
 import com.github.logi.global.entity.BaseEntity;
 import com.github.logi.global.type.VectorType;
@@ -25,6 +26,10 @@ public class Experience extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state_at_creation", length = 20)
+    private State stateAtCreation;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "experience_category", length = 20)
@@ -64,6 +69,7 @@ public class Experience extends BaseEntity {
     public static Experience create(User user, ExperienceRequest request) {
         Experience experience = new Experience();
         experience.user = user;
+        experience.stateAtCreation = user.getState();
         experience.experienceCategory = request.experienceCategory();
         experience.relatedMajor = request.relatedMajor();
         experience.experienceTitle = request.experienceTitle();

--- a/backend/src/main/java/com/github/logi/domain/experience/repository/ExperienceRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/repository/ExperienceRepository.java
@@ -96,8 +96,8 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
             SELECT e.experienceTitle AS title
             FROM Experience e
             JOIN e.user u
-            WHERE u.major = :major AND u.state = :state AND e.experienceCategory = :category
-              AND e.user <> :me
+            WHERE u.major = :major AND e.stateAtCreation = :state AND e.experienceCategory = :category
+              AND e.user <> :me AND e.relatedMajor = :relatedMajor
             ORDER BY e.createdAt DESC
             """)
     List<TitleCountView> findTopTitlesByMajorAndStateAndCategory(
@@ -105,6 +105,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
             @Param("state") State state,
             @Param("category") ExperienceCategory category,
             @Param("me") User me,
+            @Param("relatedMajor") String relatedMajor,
             Pageable pageable
     );
 
@@ -114,7 +115,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
             JOIN e.user u
             WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
               AND e.experienceCategory = :category
-              AND e.user <> :me
+              AND e.user <> :me AND e.relatedMajor = :relatedMajor
             ORDER BY e.createdAt DESC
             """)
     List<TitleCountView> findTopTitlesByMajorAndSchoolNumAndCategory(
@@ -122,6 +123,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
             @Param("schoolNumPrefix") String schoolNumPrefix,
             @Param("category") ExperienceCategory category,
             @Param("me") User me,
+            @Param("relatedMajor") String relatedMajor,
             Pageable pageable
     );
 
@@ -131,13 +133,14 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
             JOIN e.user u
             WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
               AND e.experienceCategory = :category
-              AND e.user <> :me
+              AND e.user <> :me AND e.relatedMajor = :relatedMajor
             ORDER BY e.createdAt DESC
             """)
     List<TitleCountView> findTopTitlesByMajorAndWorkerAndCategory(
             @Param("major") KookminDepartment major,
             @Param("category") ExperienceCategory category,
             @Param("me") User me,
+            @Param("relatedMajor") String relatedMajor,
             Pageable pageable
     );
 

--- a/backend/src/main/java/com/github/logi/domain/user/service/UserStatsService.java
+++ b/backend/src/main/java/com/github/logi/domain/user/service/UserStatsService.java
@@ -102,10 +102,11 @@ public class UserStatsService {
 
     private List<String> fetchTopExperienceTitles(User user, GroupContext ctx, ExperienceCategory category) {
         PageRequest page = PageRequest.of(0, RECOMMEND_TOP_N);
+        String relatedMajor = user.getMajor() != null ? user.getMajor().name() : "";
         List<ExperienceRepository.TitleCountView> views = switch (ctx.groupBy()) {
-            case STATE -> experienceRepository.findTopTitlesByMajorAndStateAndCategory(user.getMajor(), ctx.state(), category, user, page);
-            case SCHOOL_NUM -> experienceRepository.findTopTitlesByMajorAndSchoolNumAndCategory(user.getMajor(), ctx.groupKey(), category, user, page);
-            case WORKER -> experienceRepository.findTopTitlesByMajorAndWorkerAndCategory(user.getMajor(), category, user, page);
+            case STATE -> experienceRepository.findTopTitlesByMajorAndStateAndCategory(user.getMajor(), ctx.state(), category, user, relatedMajor, page);
+            case SCHOOL_NUM -> experienceRepository.findTopTitlesByMajorAndSchoolNumAndCategory(user.getMajor(), ctx.groupKey(), category, user, relatedMajor, page);
+            case WORKER -> experienceRepository.findTopTitlesByMajorAndWorkerAndCategory(user.getMajor(), category, user, relatedMajor, page);
         };
         return views.stream()
                 .map(ExperienceRepository.TitleCountView::getTitle)
@@ -128,8 +129,8 @@ public class UserStatsService {
         return switch (groupBy) {
             case STATE -> new GroupContext(groupBy, user.getState() != null ? user.getState().name() : "", user.getState());
             case SCHOOL_NUM -> {
-                String prefix = user.getSchoolNumber() != null && user.getSchoolNumber().length() >= 2
-                        ? user.getSchoolNumber().substring(0, 2)
+                String prefix = user.getSchoolNumber() != null && user.getSchoolNumber().length() >= 4
+                        ? user.getSchoolNumber().substring(0, 4)
                         : "";
                 yield new GroupContext(groupBy, prefix, null);
             }


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->
## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

경험 저장 시 경험이 언제 생성되었는지에 대한 필드 추가 및 관련 로직 변경하였습니다.
경험 생성 시 해당 유저가 언제 경험을 언제 했는지에 대한 필드과 추가되었고 통계 탭에서 부족한 경험을 추천해줄 떄 이를 고려하도록 수정하였음

- [ ] 새로운 기능 추가
- [x] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다
- [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)

## 📝 추가 노트


