### PR TITLE
[#34] 통계 페이지 api 에서 전체 순위 기능 추가 및 비효율적인 DB 관련 로직 수정

### DIFF
--- a/backend/src/main/java/com/github/logi/domain/certificate/repository/CertificateRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/certificate/repository/CertificateRepository.java
@@ -133,4 +133,46 @@ public interface CertificateRepository extends JpaRepository<Certificate, UUID> 
         String getName();
         Long getCnt();
     }
+
+    // 랭킹용: major + state 기준 유저별 자격증 수
+    @Query("""
+            SELECT c.user.id AS userId, c.user.userName AS userName, COUNT(c) AS cnt
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.state = :state
+            GROUP BY c.user.id, c.user.userName
+            """)
+    List<UserCertCountView> findCertCountPerUserByMajorAndState(
+            @Param("major") KookminDepartment major,
+            @Param("state") State state
+    );
+
+    @Query("""
+            SELECT c.user.id AS userId, c.user.userName AS userName, COUNT(c) AS cnt
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
+            GROUP BY c.user.id, c.user.userName
+            """)
+    List<UserCertCountView> findCertCountPerUserByMajorAndSchoolNum(
+            @Param("major") KookminDepartment major,
+            @Param("schoolNumPrefix") String schoolNumPrefix
+    );
+
+    @Query("""
+            SELECT c.user.id AS userId, c.user.userName AS userName, COUNT(c) AS cnt
+            FROM Certificate c
+            JOIN c.user u
+            WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
+            GROUP BY c.user.id, c.user.userName
+            """)
+    List<UserCertCountView> findCertCountPerUserByMajorAndWorker(
+            @Param("major") KookminDepartment major
+    );
+
+    interface UserCertCountView {
+        java.util.UUID getUserId();
+        String getUserName();
+        Long getCnt();
+    }
 }

--- a/backend/src/main/java/com/github/logi/domain/essay/repository/EssayQuestionRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/essay/repository/EssayQuestionRepository.java
@@ -2,6 +2,7 @@ package com.github.logi.domain.essay.repository;
 
 import com.github.logi.domain.essay.entity.EssayQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,4 +21,14 @@ public interface EssayQuestionRepository extends JpaRepository<EssayQuestion, UU
             WHERE q.id = :questionId
             """)
     Optional<EssayQuestion> findByIdWithEssayAndExperiences(@Param("questionId") UUID questionId);
+
+    // essay 삭제 시 N+1 방지: ManyToMany 조인 테이블 먼저 일괄 삭제
+    @Modifying
+    @Query(value = "DELETE FROM essay_question_experiences WHERE question_id IN (SELECT id FROM essay_questions WHERE essay_id = :essayId)", nativeQuery = true)
+    void deleteExperienceLinksByEssayId(@Param("essayId") UUID essayId);
+
+    // essay 삭제 시 N+1 방지: 문항 일괄 삭제
+    @Modifying
+    @Query(value = "DELETE FROM essay_questions WHERE essay_id = :essayId", nativeQuery = true)
+    void deleteAllByEssayIdNative(@Param("essayId") UUID essayId);
 }

--- a/backend/src/main/java/com/github/logi/domain/essay/service/EssayService.java
+++ b/backend/src/main/java/com/github/logi/domain/essay/service/EssayService.java
@@ -83,7 +83,10 @@ public class EssayService {
             throw EssayExceptions.FORBIDDEN_ESSAY.toException();
         }
 
-        essayRepository.delete(essay);
+        // cascade + orphanRemoval 대신 일괄 삭제로 N+1 방지 (문항 수와 무관하게 3쿼리 고정)
+        essayQuestionRepository.deleteExperienceLinksByEssayId(essayId);
+        essayQuestionRepository.deleteAllByEssayIdNative(essayId);
+        essayRepository.deleteById(essayId);
     }
 
     @Transactional

--- a/backend/src/main/java/com/github/logi/domain/experience/repository/ExperienceRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/experience/repository/ExperienceRepository.java
@@ -179,6 +179,49 @@ public interface ExperienceRepository extends JpaRepository<Experience, UUID> {
         Long getCnt();
     }
 
+    // 랭킹용: major + state 기준 유저별 카테고리 경험 수
+    @Query("""
+            SELECT e.user.id AS userId, e.user.userName AS userName, e.experienceCategory AS category, COUNT(e) AS cnt
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.state = :state
+            GROUP BY e.user.id, e.user.userName, e.experienceCategory
+            """)
+    List<UserCategoryCountView> findExpCountPerUserByMajorAndState(
+            @Param("major") KookminDepartment major,
+            @Param("state") State state
+    );
+
+    @Query("""
+            SELECT e.user.id AS userId, e.user.userName AS userName, e.experienceCategory AS category, COUNT(e) AS cnt
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.schoolNumber LIKE :schoolNumPrefix%
+            GROUP BY e.user.id, e.user.userName, e.experienceCategory
+            """)
+    List<UserCategoryCountView> findExpCountPerUserByMajorAndSchoolNum(
+            @Param("major") KookminDepartment major,
+            @Param("schoolNumPrefix") String schoolNumPrefix
+    );
+
+    @Query("""
+            SELECT e.user.id AS userId, e.user.userName AS userName, e.experienceCategory AS category, COUNT(e) AS cnt
+            FROM Experience e
+            JOIN e.user u
+            WHERE u.major = :major AND u.state = com.github.logi.domain.user.entity.State.WORKER
+            GROUP BY e.user.id, e.user.userName, e.experienceCategory
+            """)
+    List<UserCategoryCountView> findExpCountPerUserByMajorAndWorker(
+            @Param("major") KookminDepartment major
+    );
+
+    interface UserCategoryCountView {
+        java.util.UUID getUserId();
+        String getUserName();
+        ExperienceCategory getCategory();
+        Long getCnt();
+    }
+
     @Modifying
     @Query(value = "DELETE FROM experiences WHERE user_id = :userId", nativeQuery = true)
     void hardDeleteAllByUserId(@Param("userId") UUID userId);

--- a/backend/src/main/java/com/github/logi/domain/user/dto/response/UserStatsResponse.java
+++ b/backend/src/main/java/com/github/logi/domain/user/dto/response/UserStatsResponse.java
@@ -6,7 +6,8 @@ import java.util.List;
 
 public record UserStatsResponse(
         Statistics statistics,
-        List<WeakPoint> weakPoints
+        List<WeakPoint> weakPoints,
+        List<RankedUser> topRankers
 ) {
 
     public record Statistics(
@@ -47,5 +48,17 @@ public record UserStatsResponse(
         public static WeakPoint license(List<String> items) {
             return new WeakPoint("LICENSE", items);
         }
+    }
+
+    public record RankedUser(
+            int rank,
+            String userName,
+            int totalCount,
+            int partTimeCount,
+            int externalCount,
+            int internalCount,
+            int internCount,
+            int licenseCount
+    ) {
     }
 }

--- a/backend/src/main/java/com/github/logi/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/github/logi/domain/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import com.github.logi.domain.user.entity.JobSecond;
 import com.github.logi.domain.user.entity.JobThird;
 import com.github.logi.domain.user.entity.KookminDepartment;
 import com.github.logi.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,7 +29,8 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     List<User> findWorkersByMajorAndJobThird(
             @Param("major") KookminDepartment major,
             @Param("jobThird") JobThird jobThird,
-            @Param("me") User me
+            @Param("me") User me,
+            Pageable pageable
     );
 
     @Query("""
@@ -42,7 +44,8 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     List<User> findWorkersByMajorAndJobSecond(
             @Param("major") KookminDepartment major,
             @Param("jobSecond") JobSecond jobSecond,
-            @Param("me") User me
+            @Param("me") User me,
+            Pageable pageable
     );
 
     @Query("""
@@ -56,6 +59,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     List<User> findWorkersByMajorAndJobFirst(
             @Param("major") KookminDepartment major,
             @Param("jobFirst") JobFirst jobFirst,
-            @Param("me") User me
+            @Param("me") User me,
+            Pageable pageable
     );
 }

--- a/backend/src/main/java/com/github/logi/domain/user/service/DashboardService.java
+++ b/backend/src/main/java/com/github/logi/domain/user/service/DashboardService.java
@@ -18,6 +18,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -29,6 +32,8 @@ import static com.github.logi.domain.user.entity.GroupBy.STATE;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DashboardService {
+
+    private static final Pageable TOP_2 = PageRequest.of(0, 2);
 
     private final ExperienceRepository experienceRepository;
     private final CertificateRepository certificateRepository;
@@ -122,15 +127,15 @@ public class DashboardService {
 
     private List<User> findMatchingWorkers(User user) {
         if (user.getJobThird() != null) {
-            List<User> result = userRepository.findWorkersByMajorAndJobThird(user.getMajor(), user.getJobThird(), user);
+            List<User> result = userRepository.findWorkersByMajorAndJobThird(user.getMajor(), user.getJobThird(), user, TOP_2);
             if (!result.isEmpty()) return result;
         }
         if (user.getJobSecond() != null) {
-            List<User> result = userRepository.findWorkersByMajorAndJobSecond(user.getMajor(), user.getJobSecond(), user);
+            List<User> result = userRepository.findWorkersByMajorAndJobSecond(user.getMajor(), user.getJobSecond(), user, TOP_2);
             if (!result.isEmpty()) return result;
         }
         if (user.getJobFirst() != null) {
-            return userRepository.findWorkersByMajorAndJobFirst(user.getMajor(), user.getJobFirst(), user);
+            return userRepository.findWorkersByMajorAndJobFirst(user.getMajor(), user.getJobFirst(), user, TOP_2);
         }
         return List.of();
     }

--- a/backend/src/main/java/com/github/logi/domain/user/service/GroupStatsService.java
+++ b/backend/src/main/java/com/github/logi/domain/user/service/GroupStatsService.java
@@ -12,8 +12,11 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -86,5 +89,59 @@ public class GroupStatsService {
             double licenseAvg,
             long licenseUserCount
     ) {
+    }
+
+    @Cacheable(
+            cacheNames = CacheConfig.USER_STATS_CACHE,
+            key = "'rank_' + #major.name() + '_' + #groupBy.name() + '_' + #groupKey"
+    )
+    public List<TopRankerData> fetchTopRankers(KookminDepartment major, GroupBy groupBy, String groupKey, State state) {
+        List<ExperienceRepository.UserCategoryCountView> expCounts = switch (groupBy) {
+            case STATE -> experienceRepository.findExpCountPerUserByMajorAndState(major, state);
+            case SCHOOL_NUM -> experienceRepository.findExpCountPerUserByMajorAndSchoolNum(major, groupKey);
+            case WORKER -> experienceRepository.findExpCountPerUserByMajorAndWorker(major);
+        };
+
+        List<CertificateRepository.UserCertCountView> certCounts = switch (groupBy) {
+            case STATE -> certificateRepository.findCertCountPerUserByMajorAndState(major, state);
+            case SCHOOL_NUM -> certificateRepository.findCertCountPerUserByMajorAndSchoolNum(major, groupKey);
+            case WORKER -> certificateRepository.findCertCountPerUserByMajorAndWorker(major);
+        };
+
+        // [PARTTIME, EXTERNAL, INTERNAL, INTERN, LICENSE]
+        Map<UUID, long[]> countMap = new HashMap<>();
+        Map<UUID, String> nameMap = new HashMap<>();
+
+        for (var v : expCounts) {
+            UUID uid = v.getUserId();
+            nameMap.put(uid, v.getUserName());
+            long[] counts = countMap.computeIfAbsent(uid, k -> new long[5]);
+            int idx = switch (v.getCategory()) {
+                case PARTTIME -> 0;
+                case EXTERNAL -> 1;
+                case INTERNAL -> 2;
+                case INTERN -> 3;
+            };
+            counts[idx] = v.getCnt();
+        }
+
+        for (var v : certCounts) {
+            UUID uid = v.getUserId();
+            nameMap.putIfAbsent(uid, v.getUserName());
+            countMap.computeIfAbsent(uid, k -> new long[5])[4] = v.getCnt();
+        }
+
+        return countMap.entrySet().stream()
+                .map(e -> {
+                    long[] c = e.getValue();
+                    long total = c[0] + c[1] + c[2] + c[3] + c[4];
+                    return new TopRankerData(nameMap.get(e.getKey()), c, total);
+                })
+                .sorted(Comparator.comparingLong(TopRankerData::total).reversed())
+                .limit(3)
+                .toList();
+    }
+
+    public record TopRankerData(String userName, long[] counts, long total) {
     }
 }

--- a/backend/src/main/java/com/github/logi/domain/user/service/UserStatsService.java
+++ b/backend/src/main/java/com/github/logi/domain/user/service/UserStatsService.java
@@ -47,7 +47,8 @@ public class UserStatsService {
 
         Statistics statistics = buildStatistics(groupAvg, myCountMap, myLicenseCount);
         List<WeakPoint> weakPoints = buildWeakPoints(user, ctx, statistics);
-        return new UserStatsResponse(statistics, weakPoints);
+        List<UserStatsResponse.RankedUser> topRankers = buildTopRankers(user, ctx);
+        return new UserStatsResponse(statistics, weakPoints, topRankers);
     }
 
     private Statistics buildStatistics(GroupAvgResult groupAvg, Map<ExperienceCategory, Long> myCountMap, long myLicenseCount) {
@@ -123,6 +124,24 @@ public class UserStatsService {
                 .limit(RECOMMEND_TOP_N)
                 .map(CertificateRepository.CertNameCountView::getName)
                 .toList();
+    }
+
+    private List<UserStatsResponse.RankedUser> buildTopRankers(User user, GroupContext ctx) {
+        List<GroupStatsService.TopRankerData> rankers =
+                groupStatsService.fetchTopRankers(user.getMajor(), ctx.groupBy(), ctx.groupKey(), ctx.state());
+
+        List<UserStatsResponse.RankedUser> result = new ArrayList<>();
+        for (int i = 0; i < rankers.size(); i++) {
+            GroupStatsService.TopRankerData d = rankers.get(i);
+            long[] c = d.counts();
+            result.add(new UserStatsResponse.RankedUser(
+                    i + 1,
+                    d.userName(),
+                    (int) d.total(),
+                    (int) c[0], (int) c[1], (int) c[2], (int) c[3], (int) c[4]
+            ));
+        }
+        return result;
     }
 
     private GroupContext buildContext(User user, GroupBy groupBy) {


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->
## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->
- 통계 페이지 에서 각 분류 조건 마다 전체 경험+자격증 수가 많은 유저를 보여주는 필드 추가
- DB 삭제 과정에 n+1 문제 발견 이를 해결 하도록 코드 수정


- [x] 새로운 기능 추가
- [x] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다
- [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)

## 📝 추가 노트


