### PR TITLE
feat : 자소서 문항 저장 전에 전체 자소서 저장하지 못하게 막음

### DIFF
--- a/frontend/src/pages/Write.jsx
+++ b/frontend/src/pages/Write.jsx
@@ -244,15 +244,22 @@ function Step2({
         </button>
       )}
 
-      <div className="flex justify-end gap-2 pt-4 mt-4 border-t border-ink-150">
-        <Button onClick={onBack}>이전</Button>
-        <Button
-          variant="primary"
-          onClick={onFinish}
-          disabled={savedQuestions.length === 0}
-        >
-          <Check size={13} /> 자소서 저장 완료
-        </Button>
+      <div className="flex flex-col items-end gap-1.5 pt-4 mt-4 border-t border-ink-150">
+        {open && (
+          <span className="text-[11.5px] text-ink-500">
+            작성 중인 문항을 저장하거나 취소한 뒤에 완료할 수 있어요.
+          </span>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button onClick={onBack}>이전</Button>
+          <Button
+            variant="primary"
+            onClick={onFinish}
+            disabled={savedQuestions.length === 0 || open}
+          >
+            <Check size={13} /> 자소서 저장 완료
+          </Button>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
## 📋 변경사항 요약
자소서 문항 저장 전에 전체 자소서 저장하지 못하게 막음
<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->
## 🎯 변경 이유
자소서 문항 저장 전에 (초안 생성 시점) 자소서 저장하기 버튼을 누를 시 작성하던 문항을 수정 불가, 응답받은 초안도 (작성 중)과 같이 표시 -> 이를 로직적으로 막음
<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [ ] 새로운 기능 추가
- [v] 기존 기능 개선
- [v] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [v] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [v] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [ ] 변경사항이 기존 테스트를 통과합니다
- [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)

## 📝 추가 노트


