### PR TITLE
fix : 자소서 초안 생성 이후 문항 생성 취소하지 못하게 함

### DIFF
--- a/frontend/src/components/essay/QuestionEditor.jsx
+++ b/frontend/src/components/essay/QuestionEditor.jsx
@@ -254,7 +254,7 @@ export default function QuestionEditor({
             새 문항 작성
           </span>
         </div>
-        {onCancel && (
+        {onCancel && !draftResponse && (
           <button
             type="button"
             onClick={onCancel}


### PR DESCRIPTION
## 📋 변경사항 요약
자소서 초안 생성 이후 문항 생성 취소하지 못하게 함
<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->
## 🎯 변경 이유
초안 생성 이후 문항 엔티티가 생성되어 문항을 제거해도 문항이 그대로 남음 이를 방지하고자 로직적으로 초안 생성 시 문항 생성 취소하지 못하게 함
<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [ ] 새로운 기능 추가
- [ ] 기존 기능 개선
- [v] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [v] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [v] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [ ] 변경사항이 기존 테스트를 통과합니다
- [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)

## 📝 추가 노트


